### PR TITLE
Add company history page and navigation link

### DIFF
--- a/src/app/company-history/page.tsx
+++ b/src/app/company-history/page.tsx
@@ -1,0 +1,59 @@
+import Navigation from '@/components/Navigation';
+
+const timeline = [
+  {
+    year: '1964',
+    title: 'Founding Era',
+    description: 'Company was established with a commitment to maritime excellence.'
+  },
+  {
+    year: '1980',
+    title: 'Regional Expansion',
+    description: 'Expanded services across the region with new offices.'
+  },
+  {
+    year: '2000',
+    title: 'Technological Innovation',
+    description: 'Introduced modern classification systems to improve safety.'
+  },
+  {
+    year: '2010',
+    title: 'Global Recognition',
+    description: 'Achieved recognition from major international bodies.'
+  },
+  {
+    year: '2020',
+    title: 'Sustainable Future',
+    description: 'Focused on sustainability and digital transformation initiatives.'
+  }
+];
+
+export default function CompanyHistoryPage() {
+  return (
+    <main className="min-h-screen">
+      <Navigation />
+      <section className="bg-gradient-to-b from-[#26476c] to-[#1b3350] text-white py-24 relative overflow-hidden">
+        <div className="max-w-7xl mx-auto px-4 text-center">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Our Company History</h1>
+          <p className="text-lg md:text-xl text-white/80 max-w-3xl mx-auto">
+            A brief timeline of the milestones that shaped our growth.
+          </p>
+        </div>
+        <div className="relative max-w-3xl mx-auto mt-16">
+          <div className="absolute left-4 top-0 bottom-0 w-px bg-white/20" />
+          <div className="space-y-12">
+            {timeline.map((event) => (
+              <div key={event.year} className="relative pl-12 pb-12 border-l border-white/20 last:border-none">
+                <div className="absolute -left-3 top-1 w-6 h-6 bg-[#ecb143] rounded-full ring-4 ring-white/20" />
+                <h3 className="text-2xl font-semibold text-[#ecb143]">{event.year}</h3>
+                <h4 className="text-xl font-medium mt-1 mb-2">{event.title}</h4>
+                <p className="text-white/80">{event.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { ChevronDown, Menu, X, ChevronRight } from 'lucide-react';
+import Link from 'next/link';
 
 const Navigation = () => {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -49,64 +50,64 @@ const Navigation = () => {
     {
       title: 'About Us',
       children: [
-        'Company History',
-        'Vision & Mission',
-        'Organization Structure',
-        'Board of Directors'
+        { title: 'Company History', href: '/company-history' },
+        { title: 'Vision & Mission', href: '#' },
+        { title: 'Organization Structure', href: '#' },
+        { title: 'Board of Directors', href: '#' }
       ]
     },
     {
       title: 'Our Services',
       children: [
-        'Classification Services',
-        'Statutory Services',
-        'Consultancy Services',
-        'Supervision Services'
+        { title: 'Classification Services', href: '#' },
+        { title: 'Statutory Services', href: '#' },
+        { title: 'Consultancy Services', href: '#' },
+        { title: 'Supervision Services', href: '#' }
       ]
     },
     {
       title: 'Resources',
       children: [
-        'Technical Standards',
-        'Guidelines',
-        'Forms & Documents',
-        'Downloads'
+        { title: 'Technical Standards', href: '#' },
+        { title: 'Guidelines', href: '#' },
+        { title: 'Forms & Documents', href: '#' },
+        { title: 'Downloads', href: '#' }
       ]
     },
     {
       title: 'Publication',
       children: [
-        'Technical Journal',
-        'Annual Report',
-        'News & Updates',
-        'Press Release'
+        { title: 'Technical Journal', href: '#' },
+        { title: 'Annual Report', href: '#' },
+        { title: 'News & Updates', href: '#' },
+        { title: 'Press Release', href: '#' }
       ]
     },
     {
       title: 'Opportunity',
       children: [
-        'Career',
-        'Internship',
-        'Partnership',
-        'Tender'
+        { title: 'Career', href: '#' },
+        { title: 'Internship', href: '#' },
+        { title: 'Partnership', href: '#' },
+        { title: 'Tender', href: '#' }
       ]
     },
     {
       title: 'Gallery',
       children: [
-        'Photo Gallery',
-        'Video Gallery',
-        'Events',
-        'Achievements'
+        { title: 'Photo Gallery', href: '#' },
+        { title: 'Video Gallery', href: '#' },
+        { title: 'Events', href: '#' },
+        { title: 'Achievements', href: '#' }
       ]
     },
     {
       title: 'PPID',
       children: [
-        'Information Services',
-        'Public Information',
-        'Complaint Services',
-        'Regulations'
+        { title: 'Information Services', href: '#' },
+        { title: 'Public Information', href: '#' },
+        { title: 'Complaint Services', href: '#' },
+        { title: 'Regulations', href: '#' }
       ]
     }
   ];
@@ -172,13 +173,13 @@ const Navigation = () => {
                   }`}>
                     <div className="py-2">
                       {item.children.map((child, index) => (
-                        <a
+                        <Link
                           key={index}
-                          href="#"
+                          href={child.href}
                           className="block px-4 py-2 text-sm text-gray-700 hover:bg-[#26476c] hover:text-white transition-colors duration-200"
                         >
-                          {child}
-                        </a>
+                          {child.title}
+                        </Link>
                       ))}
                     </div>
                   </div>
@@ -251,17 +252,17 @@ const Navigation = () => {
                   }`}>
                     <div className="pl-4 pb-2 space-y-1">
                       {item.children.map((child, childIndex) => (
-                        <a
+                        <Link
                           key={childIndex}
-                          href="#"
+                          href={child.href}
                           className="block p-3 text-sm text-gray-600 hover:text-[#ecb143] hover:bg-[#ecb143]/5 rounded-md transition-all duration-200 transform hover:translate-x-1"
                           onClick={() => {
                             setIsMobileMenuOpen(false);
                             setActiveMobileDropdown(null);
                           }}
                         >
-                          {child}
-                        </a>
+                          {child.title}
+                        </Link>
                       ))}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- add dedicated **Company History** page with gradient hero section and placeholder timeline
- wire navigation dropdown items to use Next.js `Link` and link Company History entry to the new page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68922d756db083249ebd3d160f9dab9b